### PR TITLE
Added support for chaining and for describing each path as an object (containing path and method)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var URL = require('url');
 
 var middleware = function (options) {
   var parent = this;
-  //console.log("[unless] options = %s, this = %s", JSON.stringify(options), this);
 
   var opts = typeof options === 'function' ? {custom: options} : options;
 
@@ -18,7 +17,6 @@ var middleware = function (options) {
     var paths = !opts.path || Array.isArray(opts.path) ?
                 opts.path : [opts.path];
 
-    //console.log("[unless] paths: %s", JSON.stringify(paths));
     if (paths) {
       skip = skip || paths.some(function (path) {
     	if(path instanceof Object && !(path instanceof RegExp)){
@@ -27,7 +25,6 @@ var middleware = function (options) {
     	}else{
         	var p = path;
     	}
-        //console.log("[unless] path: %s, req.method: %s, m: %s, Array.isArray(m): %s, !!~m.indexOf(req.method): %s", p, req.method, m, Array.isArray(m), m && !!~m.indexOf(req.method));
         return (
           (typeof p === 'string' && p === url.pathname)
           || (p instanceof RegExp && !!p.exec(url.pathname)))
@@ -57,8 +54,6 @@ var middleware = function (options) {
     }
 
     if (skip) {
-    	//console.log("[express-jwt:unless] skipping for: req.method = %s, req.url = %s", 
-    	//	req.method, req.url);
       return next();
     }
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var URL = require('url');
 
-module.exports = function (options) {
+var middleware = function (options) {
   var parent = this;
+  //console.log("[unless] options = %s, this = %s", JSON.stringify(options), this);
 
   var opts = typeof options === 'function' ? {custom: options} : options;
 
-  return function (req, res, next) {
+  var unless = function (req, res, next) {
     var url = URL.parse(req.originalUrl || req.url || '', true);
 
     var skip = false;
@@ -17,10 +18,23 @@ module.exports = function (options) {
     var paths = !opts.path || Array.isArray(opts.path) ?
                 opts.path : [opts.path];
 
+    //console.log("[unless] paths: %s", JSON.stringify(paths));
     if (paths) {
-      skip = skip || paths.some(function (p) {
-        return (typeof p === 'string' && p === url.pathname) ||
-               (p instanceof RegExp && !!p.exec(url.pathname));
+      skip = skip || paths.some(function (path) {
+    	if(path instanceof Object && !(path instanceof RegExp)){
+    		var p = path.p;
+    		var m = path.m;
+    	}else{
+        	var p = path;
+    	}
+        //console.log("[unless] path: %s, req.method: %s, m: %s, Array.isArray(m): %s, !!~m.indexOf(req.method): %s", p, req.method, m, Array.isArray(m), m && !!~m.indexOf(req.method));
+        return (
+          (typeof p === 'string' && p === url.pathname)
+          || (p instanceof RegExp && !!p.exec(url.pathname)))
+        && (!m
+          || (typeof m === 'string' && m === req.method)
+          || (Array.isArray(m) && !!~m.indexOf(req.method))
+          );
       });
     }
 
@@ -33,6 +47,8 @@ module.exports = function (options) {
       });
     }
 
+    // mprinc
+    // It has to be fast, avoid wrapping in Array
     var methods = !opts.method || Array.isArray(opts.method) ?
                   opts.method : [opts.method];
 
@@ -41,9 +57,16 @@ module.exports = function (options) {
     }
 
     if (skip) {
+    	//console.log("[express-jwt:unless] skipping for: req.method = %s, req.url = %s", 
+    	//	req.method, req.url);
       return next();
     }
 
     parent(req, res, next);
   };
+  
+  unless.unless = middleware; // fluid interface, chainable
+  return unless;
 };
+
+module.exports = middleware;

--- a/index.js
+++ b/index.js
@@ -44,8 +44,6 @@ var middleware = function (options) {
       });
     }
 
-    // mprinc
-    // It has to be fast, avoid wrapping in Array
     var methods = !opts.method || Array.isArray(opts.method) ?
                   opts.method : [opts.method];
 

--- a/test/unless.tests.js
+++ b/test/unless.tests.js
@@ -19,17 +19,14 @@ describe('express-unless', function () {
       var req = {
         originalUrl: '/test?das=123'
       };
-
       mid(req, {}, noop);
-
       assert.notOk(req.called);
+
 
       req = {
         originalUrl: '/fobo?test=123'
       };
-
       mid(req, {}, noop);
-
       assert.notOk(req.called);
     });
 
@@ -37,12 +34,141 @@ describe('express-unless', function () {
       var req = {
         originalUrl: '/foobar/test=123'
       };
-
       mid(req, {}, noop);
-
       assert.ok(req.called);
     });
   });
+
+  describe('with single PATH (obj)', function () {
+	    var mid = testMiddleware.unless({
+	      path: {p: '/nada'}
+	    });
+	    it('should not call the middleware when one of the path match', function () {
+	      var req = {
+	        originalUrl: '/nada'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      var req = {
+	        originalUrl: '/nada?das=123',
+	        method: 'OPTIONS'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+	    });
+
+	    it('should call the middleware when the path doesnt match', function () {
+	      var req = {
+	  	        originalUrl: '/foobar'
+	  	      };
+	  	      mid(req, {}, noop);
+	  	      assert.ok(req.called);
+
+	  	      var req = {
+	        originalUrl: '/foobar/test=123'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+	    });
+	  });
+
+  describe('with single PATH (obj with method)', function () {
+	    var mid = testMiddleware.unless({
+	      path: {p: '/nada', m: ['OPTIONS', 'GET']}
+	    });
+	    it('should not call the middleware when one of the path match', function () {
+	      var req = {
+	        originalUrl: '/nada',
+            method: 'OPTIONS'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      var req = {
+	        originalUrl: '/nada?das=123',
+            method: 'GET'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+	    });
+
+	    it('should call the middleware when the path doesnt match', function () {
+	      var req = {
+  	        originalUrl: '/foobar'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.ok(req.called);
+
+  	      var req = {
+	        originalUrl: '/nada/test=123',
+            method: 'PUT'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+	    });
+	  });
+
+  describe('with array of PATHs (obj with method)', function () {
+	    var mid = testMiddleware.unless({
+	      path: [
+ 	        '/milica',
+	        {p: '/nada', m: 'OPTIONS'},
+	        {p: '/mile', m: ['DELETE', 'PUT']}
+	      ]
+	    });
+	    it('should not call the middleware when one of the path match', function () {
+	      var req = {
+	        originalUrl: '/milica',
+            method: 'OPTIONS'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      var req = {
+	        originalUrl: '/nada?das=123',
+            method: 'OPTIONS'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      var req = {
+  	        originalUrl: '/mile?das=123',
+  	        method: 'DELETE'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      var req = {
+	        originalUrl: '/mile?das=123',
+	        method: 'PUT'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.notOk(req.called);
+	    });
+
+	    it('should call the middleware when the path doesnt match', function () {
+	      var req = {
+	        originalUrl: '/foobar'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+
+	      var req = {
+	        originalUrl: '/nada/test=123',
+            method: 'PUT'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+
+	      var req = {
+  	        originalUrl: '/mile/test=123',
+  	        method: 'GET'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.ok(req.called);
+	    });
+	  });
 
   describe('with PATH (regex) exception', function () {
     var mid = testMiddleware.unless({
@@ -60,6 +186,45 @@ describe('express-unless', function () {
     });
 
   });
+
+  describe('with PATH (obj) (regex) exception', function () {
+	    var mid = testMiddleware.unless({
+	      path: ['/test', '/fobo', {p: /da+/}, {p: /ag$/ig, m: 'GET'}]
+	    });
+
+	    it('should not call the middleware when the regex match', function () {
+
+	      req = {
+  	        originalUrl: '/nadaa?test=123',
+  	        method: 'GET'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.notOk(req.called);
+
+  	      req = {
+	        originalUrl: '/foboag?test=123',
+            method: 'GET'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+	    });
+
+	    it('should call the middleware when the path doesnt match', function () {
+	      req = {
+  	        originalUrl: '/foboaga?test=123',
+  	        method: 'GET'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.ok(req.called);
+
+  	      req = {
+	        originalUrl: '/foboag?test=123',
+          method: 'PUT'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+	    });
+	  });
 
   describe('with EXT exception', function () {
     var mid = testMiddleware.unless({
@@ -140,5 +305,62 @@ describe('express-unless', function () {
       assert.ok(req.called);
     });
   });
+
+  describe('with CHAINED UNLESS', function () {
+	    var mid = testMiddleware
+	    	.unless({path: ['/test', '/fobo']})
+	    	.unless({path: {p: '/nada', m: ['PUT', 'GET']}})
+	    	.unless({method: ['OPTIONS']});
+
+	    it('should not call the middleware when one of the path match', function () {
+	      var req = {
+	        originalUrl: '/test?das=123'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      req = {
+	        originalUrl: '/fobo?test=123'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      req = {
+	        originalUrl: '/nada?test=123',
+	        method: 'GET'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+
+	      req = {
+	        originalUrl: '/anything',
+	        method: 'OPTIONS'
+	      };
+	      mid(req, {}, noop);
+	      assert.notOk(req.called);
+	    });
+
+	    it('should call the middleware when the path doesnt match', function () {
+	      var req = {
+	        originalUrl: '/testing'
+	      };
+	      mid(req, {}, noop);
+	      assert.ok(req.called);
+
+	      var req = {
+  	        originalUrl: '/nada',
+	        method: 'POST'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.ok(req.called);
+
+	      var req = {
+  	        originalUrl: '/wrong',
+	        method: 'POST'
+  	      };
+  	      mid(req, {}, noop);
+  	      assert.ok(req.called);
+	    });
+	  });
 
 });


### PR DESCRIPTION
Added support for chaining:
            .unless({path: ['/test', '/fobo']})
            .unless({path: {p: '/nada', m: ['PUT', 'GET']}})
            .unless({method: ['OPTIONS']});

Added support for path describing as object
.unless({
          path: [
            '/milica',
            {p: '/nada', m: 'OPTIONS'},
            {p: '/mile', m: ['DELETE', 'PUT']}
          ]
        });
