### PR TITLE
add option useOriginalUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ module.exports = function (middlewareOptions) {
 -  `path` it could be an string, a regexp or an array of any of those. If the request path match, the middleware will not run.
 -  `ext` it could be an string or an array of strings. If the request path ends with one of these extensions the middleware will not run.
 -  `custom` it must be a function that accepts `req` and returns `true` / `false`. If the function returns true for the given request, ithe middleware will not run.
+-  `useOriginalUrl` it should be `true` or `false`, default is `true`. if false, `path` will match against `req.url` instead of `req.originalUrl`. Please refer to [Express API](http://expressjs.com/4x/api.html#request) for the difference between `req.url` and `req.originalUrl`.
 
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ module.exports = function (options) {
   var parent = this;
 
   var opts = typeof options === 'function' ? {custom: options} : options;
+  opts.useOriginalUrl = (typeof opts.useOriginalUrl === 'undefined') ? true : opts.useOriginalUrl;
 
   return function (req, res, next) {
-    var url = URL.parse(req.originalUrl || req.url || '', true);
+    var url = URL.parse((opts.useOriginalUrl ? req.originalUrl : req.url) || '', true);
 
     var skip = false;
 

--- a/test/unless.tests.js
+++ b/test/unless.tests.js
@@ -61,6 +61,46 @@ describe('express-unless', function () {
 
   });
 
+  describe('with PATH (useOriginalUrl) exception', function () {
+    var mid = testMiddleware.unless({
+      path: ['/test', '/fobo'],
+      useOriginalUrl: false
+    });
+
+    it('should not call the middleware when one of the path match '+
+        'req.url instead of req.originalUrl', function () {
+      var req = {
+        originalUrl: '/orig/test?das=123',
+        url: '/test?das=123'
+      };
+
+      mid(req, {}, noop);
+
+      assert.notOk(req.called);
+
+      req = {
+        originalUrl: '/orig/fobo?test=123',
+        url: '/fobo?test=123'
+      };
+
+      mid(req, {}, noop);
+
+      assert.notOk(req.called);
+    });
+
+    it('should call the middleware when the path doesnt match '+
+        'req.url even if path matches req.originalUrl', function () {
+      var req = {
+        originalUrl: '/test/test=123',
+        url: '/foobar/test=123'
+      };
+
+      mid(req, {}, noop);
+
+      assert.ok(req.called);
+    });
+  });
+
   describe('with EXT exception', function () {
     var mid = testMiddleware.unless({
       ext: ['jpg', 'html', 'txt']


### PR DESCRIPTION
add option useOriginalUrl to allow path to match against req.url instead of req.originalUrl.