### PR TITLE
resetting regex index after each match

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ module.exports = function (options) {
 
     if (paths) {
       skip = skip || paths.some(function (p) {
-        return (typeof p === 'string' && p === url.pathname) ||
-               (p instanceof RegExp && !!p.exec(url.pathname));
+        var ret = (typeof p === 'string' && p === url.pathname) || (p instanceof RegExp && !!p.exec(url.pathname));
+        if (p instanceof RegExp)
+          p.lastIndex = 0;
+        return ret;
       });
     }
 


### PR DESCRIPTION
This PR fixes a bug that shows up when matching a regex path. Since the RegEx object is stateful, the index needs to be reset each time a match is found otherwise the next iteration will fail to match.