### PR TITLE
If req.originalUrl is not defined use req.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (options) {
   opts.useOriginalUrl = (typeof opts.useOriginalUrl === 'undefined') ? true : opts.useOriginalUrl;
 
   return function (req, res, next) {
-    var url = URL.parse((opts.useOriginalUrl ? req.originalUrl : req.url) || '', true);
+    var url = URL.parse((opts.useOriginalUrl ? req.originalUrl : req.url) || req.url || '', true);
 
     var skip = false;
 

--- a/test/unless.tests.js
+++ b/test/unless.tests.js
@@ -44,7 +44,7 @@ describe('express-unless', function () {
     });
   });
 
-  describe.only('with PATH (regex) exception', function () {
+  describe('with PATH (regex) exception', function () {
     var mid = testMiddleware.unless({
       path: ['/test', /ag$/ig]
     });
@@ -179,6 +179,32 @@ describe('express-unless', function () {
     it('should call the middleware when the custom rule doesnt match', function () {
       var req = {
         baba: false
+      };
+
+      mid(req, {}, noop);
+
+      assert.ok(req.called);
+    });
+  });
+
+  describe('without originalUrl', function () {
+    var mid = testMiddleware.unless({
+      path: ['/test']
+    });
+
+    it('should not call the middleware when one of the path match', function () {
+      var req = {
+        url: '/test?das=123'
+      };
+
+      mid(req, {}, noop);
+
+      assert.notOk(req.called);
+    });
+
+    it('should call the middleware when the path doesnt match', function () {
+      var req = {
+        url: '/foobar/test=123'
       };
 
       mid(req, {}, noop);


### PR DESCRIPTION
Despite this being "express"-unless I have been using with restify for which it works perfectly except for the fact that restify does not seem to create the req.originalUrl object. Rather then having to supply {..., useOriginalUrl: false} with every call I added back in the failover to using req.url if req.originalUrl is undefined. This behaviour was available in version 0.0.0 but instead of using an old version, I decided to add it back in and make a pull request. (Simple one line edit)

Also added a test for this behaviour. All tests passing