### PR TITLE
Support single `method` option for objects in `path` array

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ module.exports = function (options) {
       skip = skip || opts.custom(req);
     }
 
-    var paths = !opts.path || Array.isArray(opts.path) ?
-                opts.path : [opts.path];
+    var paths = oneOrMany(opts.path);
 
     if (paths) {
       skip = skip || paths.some(function (p) {
-        return isUrlMatch(p, url.pathname) && isMethodMatch(p.methods, req.method);
+        var methods = p.methods || oneOrMany(p.method);
+        return isUrlMatch(p, url.pathname) && isMethodMatch(methods, req.method);
       });
     }
 
@@ -33,8 +33,7 @@ module.exports = function (options) {
       });
     }
 
-    var methods = (!opts.method || Array.isArray(opts.method)) ?
-                  opts.method : [opts.method];
+    var methods = oneOrMany(opts.method);
 
     if (methods) {
       skip = skip || !!~methods.indexOf(req.method);
@@ -47,6 +46,11 @@ module.exports = function (options) {
     parent(req, res, next);
   };
 };
+
+function oneOrMany(elementOrArray) {
+  return !elementOrArray || Array.isArray(elementOrArray) ?
+    elementOrArray : [elementOrArray];
+}
 
 function isUrlMatch(p, url) {
   var ret = (typeof p === 'string' && p === url) || (p instanceof RegExp && !!p.exec(url));
@@ -65,7 +69,7 @@ function isMethodMatch(methods, m) {
     return true;
   }
 
-  methods = Array.isArray(methods) ? methods : [methods];
+  methods = oneOrMany(methods);
 
   return !!~methods.indexOf(m);
 }

--- a/test/unless.tests.js
+++ b/test/unless.tests.js
@@ -19,7 +19,7 @@ describe('express-unless', function () {
         },
         {
           url: '/bar',
-          methods: ['PUT']
+          method: 'PUT'
         },
         '/foo'
       ]
@@ -63,6 +63,14 @@ describe('express-unless', function () {
       req = {
         originalUrl: '/test?test=123',
         method: 'PUT'
+      };
+
+      mid(req, {}, noop);
+      assert.ok(req.called);
+
+      req = {
+        originalUrl: '/bar?test=123',
+        method: 'GET'
       };
 
       mid(req, {}, noop);


### PR DESCRIPTION
`method` is supported as an option for the top-most level of configuration, but when used for an object in the `path` array then it must be `methods`. It's not a big deal, but the mistake can be easily missed, e.g. with the following configuration:

```
app.use(authMiddleware.unless({
  path: [
    { url: '/something', method: 'GET' }
  ]
})
```

Then the middleware wouldn't execute on `GET` so at first sight it might seem that everything's working fine, but it will actually be skipped on **every** method, since `methods` is `undefined`. This means that one could inadvertently allow any user to make a `PUT`, `POST`, or `DELETE` to a resource that should be secured, in the case of authentication middleware.

The proposed solution allows a `method` option on each object in the `path` array that can be a string or array of strings, but it doesn't remove the `methods` option nor change its behavior to preserve backwards compatibility. Hope it helps!
