### PR TITLE
types: export types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "/dist"
   ],
   "main": "./dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
fixes error TS2688: Cannot find type definition file for 'express-unless'.
  The file is in the program because:
    Entry point for implicit type library 'express-unless'