### PR TITLE
Update express-unless with new types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,17 +74,17 @@ function toArray<T>(elementOrArray: T | T[]): T[] {
   return Array.isArray(elementOrArray) ? elementOrArray : [elementOrArray];
 }
 
-function isUrlMatch(p: string | RegExp | { url: string | RegExp }, url: string) {
-  if (typeof p === 'string') {
-    return p === url;
+function isUrlMatch(path: string | RegExp | { url: string | RegExp }, url: string): boolean {
+  if (typeof path === 'string') {
+    return path === url;
   }
 
-  if (p instanceof RegExp) {
-    return url.match(p) !== null;
+  if (path instanceof RegExp) {
+    return url.match(path) !== null;
   }
 
-  if (typeof p === 'object' && p.url) {
-    return isUrlMatch(p.url, url);
+  if (typeof path === 'object' && path.url) {
+    return isUrlMatch(path.url, url);
   }
 
   return false;

--- a/test/unless.tests.ts
+++ b/test/unless.tests.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { unless } from '../src/index';
+import { unless } from '../src';
 import { assert } from 'chai';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = function () { };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "outDir": "./dist",
     "allowJs": true,
-    "target": "es6",
+    "target": "es2016",
     "module": "CommonJS",
     "declaration": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "esModuleInterop": true
   },
   "include": [
     "./src/*"


### PR DESCRIPTION
Hello @jfromaniello,

Here is a proposition to refresh the project in typescript, I have:
- Added a new UnlessRequestHandler type (so it can be used outside of this package)
- updated some variable name 
- extracted the result into a method
- Use some smaller notation (like anonymous function and ternary operator)
- Return `next()` or `middleware()` to handle asynchronous behaviour

I was thinking `Params` could be named `UnlessOptions` but didn't want to make a breaking change there.

Let me know what you think

All tests are passing:
![image](https://github.com/jfromaniello/express-unless/assets/20642750/70547c38-f395-4f16-9f5b-6b994e015905)
